### PR TITLE
pt_BR Reset to Defaults button

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -573,7 +573,7 @@ msgstr "Tecla _delete gera:"
 
 #: ../data/prefs.glade.h:106
 msgid "_Reset Compatibility Options to Defaults"
-msgstr "_Restaurar padrões para as opções de compatibilidade"
+msgstr "_Restaurar as opções de compatibilidade padrão"
 
 #: ../data/prefs.glade.h:107
 msgid "<b>Keyboard compatibility</b>"


### PR DESCRIPTION
"_Reset Compatibility Options to Defaults" button title was translated better as "_Restaurar as opções de compatibilidade padrão"
